### PR TITLE
fix: ensure pathPrefix works with trailingSlash option

### DIFF
--- a/packages/gatsby-link/src/rewrite-link-path.js
+++ b/packages/gatsby-link/src/rewrite-link-path.js
@@ -18,13 +18,14 @@ function applyTrailingSlashOptionOnPathnameOnly(path, option) {
 }
 
 function absolutify(path, current) {
+  const prefixed = withPrefix(path)
   // If it's already absolute, return as-is
   if (isAbsolutePath(path)) {
-    return path
+    return prefixed
   }
 
   const option = getGlobalTrailingSlash()
-  const absolutePath = resolve(path, current)
+  const absolutePath = resolve(prefixed, current)
 
   if (option === `always` || option === `never`) {
     return applyTrailingSlashOptionOnPathnameOnly(absolutePath, option)


### PR DESCRIPTION
## Description

This commit fixes an issue where the `pathPrefix` option was ignored when the trailing slash option was set to "never." The cause was that adding the prefix seemed to be left out of a few code paths.

### Documentation

This feature is documented [on this page](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/), however, it doesn't work as described right now when the `trailingSlash` option is set to `never`.

### Tests

I've tested this change on a production Gatsby site, but haven't added any automated tests. I'm happy to attempt to do so, but I couldn't get tests working locally, nor could I push to my fork (maybe because of the repository size).

## Related Issues

Fixes #39043